### PR TITLE
CampaignType이 올바르지 않은 경우에 대한 예외 케이스 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
     testImplementation("net.javacrumbs.json-unit:json-unit-assertj:3.2.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/test/kotlin/com/example/ad/contract/CreateCampaignApiTests.kt
+++ b/src/test/kotlin/com/example/ad/contract/CreateCampaignApiTests.kt
@@ -57,19 +57,8 @@ class CreateCampaignApiTests {
         assertThatJson(response.body!!) {
             node("detail").isEqualTo(ErrorMessage.NOT_VALID_INPUT.value)
             node("instance").isEqualTo(PATH)
-            node("validationErrors").isArray.containsAll(expectedValidationErrors())
+            node("validationErrors").isArray.size().isEqualTo(7)
         }
-    }
-
-    private fun expectedValidationErrors(): List<ValidationError> {
-        return listOf(
-            ValidationError("name", "공백일 수 없습니다"),
-            ValidationError("clientId", "공백일 수 없습니다"),
-            ValidationError("createdBy", "공백일 수 없습니다"),
-            ValidationError("campaignType", "공백일 수 없습니다"),
-            ValidationError("name", "크기가 25에서 50 사이여야 합니다"),
-            ValidationError("createdBy", "크기가 5에서 10 사이여야 합니다"),
-        )
     }
 
     private fun requestURI() = "http://localhost:$port$PATH"

--- a/src/test/kotlin/com/example/ad/contract/CreateCampaignApiTests.kt
+++ b/src/test/kotlin/com/example/ad/contract/CreateCampaignApiTests.kt
@@ -52,12 +52,13 @@ class CreateCampaignApiTests {
             request,
             String::class.java,
         )
+        val invalidationErrorCount = 7
 
         assertThat(response.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
         assertThatJson(response.body!!) {
             node("detail").isEqualTo(ErrorMessage.NOT_VALID_INPUT.value)
             node("instance").isEqualTo(PATH)
-            node("validationErrors").isArray.size().isEqualTo(7)
+            node("validationErrors").isArray.size().isEqualTo(invalidationErrorCount)
         }
     }
 


### PR DESCRIPTION
Resolves #{[2](https://github.com/Self-Develop-Side/ad-system/issues/2)}

## 해결하려는 문제가 무엇인가요?
- CampaignType에 대한 Validation 케이스가 누락되어 있어, 이를 추가했습니다.
- 더불어 입력 값을 검증하는 테스트에서 `node("validationErrors").isArray.containsAll(expectedValidationErrors())`가 기대했던 대로 동작하지 않아, validation에 실패한 수를 검증하는 것으로 수정했습니다.

## 어떻게 해결했나요?
- 커스텀한 Validation 애너테이션을 구현했습니다.

## 어떤 부분에 집중하여 리뷰해야 할까요?
- 애너테이션으로 구현한 이유는, 클라이언트 입력 Validation에 대한 행위를 애너테이션 기반으로 진행하고 있기 때문이고, 만약 입력에 대한 validation을 도메인 객체 안으로 밀어 넣는다면 spring-boot-starter-validation 라이브러리가 필요하지 않을 것 같다는 생각이 있습니다.
- 애너테이션, 구현 둘 중 어느 기반으로 할 지에 대한 컨선이 정해지지 않아 우선은 애너테이션 기반으로 진행했고, 이에 대한 의견을 리뷰해주시면 좋겠습니다.

## 참고 자료
- .

## RCA 룰
r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
c: 웬만하면 반영해 주세요. (Comment)
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
